### PR TITLE
CompatHelper: add new compat entry for Downloads at version 1, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,13 @@ version = "1.0.0-DEV"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
 
-
 [compat]
+Downloads = "1"
 julia = "1.10.3"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 NLPModelsIpopt = "f4238b75-b362-5c4c-b852-0801c9a21d71"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "NLPModelsIpopt"]


### PR DESCRIPTION
This pull request sets the compat entry for the `Downloads` package to `1`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.